### PR TITLE
Only download one track at a time (fixes #14)

### DIFF
--- a/app.js
+++ b/app.js
@@ -273,6 +273,7 @@ function download (track) {
 
 function downloadAlbum (album) {
   var deferred = Q.defer();
+  var lastDownload = Q('dummy');
 
   playmusic.getAlbum(album.albumId, true, function (err, fullAlbumDetails) {
     if (err) {
@@ -288,14 +289,15 @@ function downloadAlbum (album) {
 
     cli.progress(0 / cli.album.total);
 
-
-    var downloadPromises = fullAlbumDetails.tracks.map(function (track) {
+    fullAlbumDetails.tracks.forEach(function (track) {
       track.albumArtist = fullAlbumDetails.albumArtist;
       m3uWriter.file(getTrackFilename(track));
-      return download(track);
+      lastDownload = lastDownload.then(function(value) {
+        return download(track);
+      });
     });
 
-    Q.all(downloadPromises).then(function () {
+    lastDownload.then(function () {
       cli.spinner('', true);
       if (cli.options.downloadonly) {
         writePlaylist(m3uWriter, album);


### PR DESCRIPTION
It appears that starting all downloads for an album increases the risk
of corrupting one of the tracks, especially if one of those tracks is
very long, though the exact cause for this is yet unclear.  This change
chains the promises for downloading the tracks in series instead of in
parallel which appears to greatly reduce/practically eliminate the risk
of corruption.

Given that the bottleneck for downloading many files is network
bandwidth, downloading all the files in parallel should not (in theory)
increase the wall-time of the download.  Unfortunately in practice, this
does not prove to be the case.  Cursory empirical tests have shown this
approach to be about 50% slower, so this may not be the best approach.

Request for comment/review
--------------------------

Further changes that could alleviate the issue of slowness could be:

- tune gmplayer to download 2 or 3 at a time to get the best bandwidth
  without risking file corruption
- make gmplayer start playing the playlist/first track after the first
  file has finished downloading so that the user does not experience a
  long wait while the rest of the album finishes downloading
- invent quantum internet protocol to download all of the tracks
  simultaneously instantly without corruption